### PR TITLE
Add more informative extra/missing column error messages, auto-convert dates to YYYY-MM-DD format and allow users to upload metadata columns containing only required columns.

### DIFF
--- a/jdrf/jdrf/metadata_schema.py
+++ b/jdrf/jdrf/metadata_schema.py
@@ -24,14 +24,15 @@ study_schema = Schema([
 
 sample_schema = Schema([
     Column('host_subject_id', [MatchesPatternValidation(r'\w+', message='Host Subject ID may only contain alphanumeric characters.')]),
-    Column('host_diet', [LeadingWhitespaceValidation()]),
-    Column('source_material_id', [LeadingWhitespaceValidation()]),
-    Column('ethnicity', [CanConvertValidation(str, message='Ethnicity may only contain alphanumeric characters.')]),
-    Column('host_family_relationship', [LeadingWhitespaceValidation()]),
+    Column('host_diet', [LeadingWhitespaceValidation()], allow_empty=True),
+    Column('source_material_id', [LeadingWhitespaceValidation()], allow_empty=True),
+    Column('ethnicity', [CanConvertValidation(str, message='Ethnicity may only contain alphanumeric characters.')], allow_empty=True),
+    Column('host_family_relationship', [LeadingWhitespaceValidation()], allow_empty=True),
     Column('host_genotype', [LeadingWhitespaceValidation() |
-                             MatchesPatternValidation(r'^[http|www]', message='Host Genotype may only be a valid URL to the associated DbGap project.')]),
-    Column('isolation_source', [LeadingWhitespaceValidation()]),
-    Column('samp_mat_process', [LeadingWhitespaceValidation()]),
+                             MatchesPatternValidation(r'^[http|www]', message='Host Genotype may only be a valid URL to the associated DbGap project.')],
+           allow_empty=True),
+    Column('isolation_source', [LeadingWhitespaceValidation()], allow_empty=True), 
+    Column('samp_mat_process', [LeadingWhitespaceValidation()], allow_empty=True),
     Column('filename', [CustomSeriesValidation(lambda x: ~x.isnull(), 'A value is required for the filename column.'),
                         MatchesPatternValidation(r'\w+.[fastq|fasta|fq](.gz)?', message='Filename must be a valid fasta/fastq file with the following supported extensions: .fasta.gz, .fastq.gz, fq.gz')]),
     Column('sample_id', [CustomSeriesValidation(lambda x: ~x.isnull(), 'A value is required for the sample_id column.')]),
@@ -44,32 +45,36 @@ sample_schema = Schema([
                            InListValidation(['M', 'm', 'F', 'f'])]),
     Column('md5_checksum', [CustomSeriesValidation(lambda x: ~x.isnull(), 'A value is required for the pi_name column.'),
                             MatchesPatternValidation(r'[a-zA-Z0-9]{32}', message='MD5 Checksum may only contain 32 alphanumeric characters.')]),
-    Column('host_body_mass_index', [LeadingWhitespaceValidation() | CanConvertValidation(float)]),
+    Column('host_body_mass_index', [LeadingWhitespaceValidation() | CanConvertValidation(float)], allow_empty=True),
     Column('host_disease', [LeadingWhitespaceValidation() | 
-                            MatchesPatternValidation(r'DOID:\d+', message='Must provide a valid Disease Ontology ID in format \'DOID:<NUMBERS>\'')]),
+                            MatchesPatternValidation(r'DOID:\d+', message='Must provide a valid Disease Ontology ID in format \'DOID:<NUMBERS>\'')],
+           allow_empty=True),
     Column('variable_region', [CustomSeriesValidation(lambda x: ~x.isnull(), '') |
-                               MatchesPatternValidation(r'(V[1-9],?)+', message='Variable region must be a valid 16S hypervariable region.')]),
-    Column('gastrointest_disord', [LeadingWhitespaceValidation() | CanConvertValidation(int)]),
+                               MatchesPatternValidation(r'(V[1-9],?)+', message='Variable region must be a valid 16S hypervariable region.')],
+           allow_empty=True),
+    Column('gastrointest_disord', [LeadingWhitespaceValidation() | CanConvertValidation(int)], allow_empty=True),
     Column('host_body_product', [LeadingWhitespaceValidation() |
-                                 MatchesPatternValidation(r'GENEPIO_\d+', message='Must provide a valid Genetic epidemiology ontology ID in format \'GENEPIO_<NUMBERS>\'')]),
-    Column('host_phenotype', [LeadingWhitespaceValidation() | CanConvertValidation(int)]),
+                                 MatchesPatternValidation(r'GENEPIO_\d+', message='Must provide a valid Genetic epidemiology ontology ID in format \'GENEPIO_<NUMBERS>\'')],
+           allow_empty=True),
+    Column('host_phenotype', [LeadingWhitespaceValidation() | CanConvertValidation(int)], allow_empty=True),
     Column('ihmc_medication_code', [CustomSeriesValidation(lambda x: ~x.isnull(), '') |
-                                    MatchesPatternValidation(r'(\d+,?)+]', message='IHMC medication code must be a number.')]),
+                                    MatchesPatternValidation(r'(\d+,?)+]', message='IHMC medication code must be a number.')], allow_empty=True),
     Column('organism_count', [CustomSeriesValidation(lambda x: ~x.isnull(), '') |
-                              InRangeValidation(1, message='Organism count must be a positive number.')]),
+                              InRangeValidation(1, message='Organism count must be a positive number.')], allow_empty=True),
     Column('samp_store_dur', [LeadingWhitespaceValidation() | 
-                              InRangeValidation(1, message='Sample storage duration must be a positive number.')]),
+                              InRangeValidation(1, message='Sample storage duration must be a positive number.')], allow_empty=True),
     Column('samp_store_temp', [LeadingWhitespaceValidation() | 
-                               CanConvertValidation(int, message='Sample storage temperature must be a valid temperature number.')]),
+                               CanConvertValidation(int, message='Sample storage temperature must be a valid temperature number.')], allow_empty=True),
     Column('samp_vol_mass', [LeadingWhitespaceValidation() |
-                             MatchesPatternValidation(r'\d+[.]?\d*(g|ml)', message='Sample volume mass must be in format <NUMBER>g or <NUMBER>ml')]),
+                             MatchesPatternValidation(r'\d+[.]?\d*(g|ml)', message='Sample volume mass must be in format <NUMBER>g or <NUMBER>ml')], 
+           allow_empty=True),
     Column('sequencer', [InListValidation(["Illumina MiSeq", "Illumina NextSeq", "illumina miseq", "illumina nextseq",
                                            "Illumina HiSeq", "Illumina HiSeq X", "illumina hiseq", "illumina hiseq x",
                                            "PacBio Sequel", "Nanopore MinION", "pacbio sequel", "nanopore minion",
                                            "Nanopore PromethION", "Nanopore SmidgION", "nanopore promethion", "nanopore smidgion",
                                            "454", "Sanger", "sanger"])]),
     Column('read_number', [LeadingWhitespaceValidation() |
-                           InRangeValidation(1, message='Read number must be a positive number.')])
+                           InRangeValidation(1, message='Read number must be a positive number.')], allow_empty=True)
 ])
 
 schemas = {'sample': sample_schema, 'study': study_schema}

--- a/jdrf/jdrf/metadata_schema.py
+++ b/jdrf/jdrf/metadata_schema.py
@@ -24,15 +24,14 @@ study_schema = Schema([
 
 sample_schema = Schema([
     Column('host_subject_id', [MatchesPatternValidation(r'\w+', message='Host Subject ID may only contain alphanumeric characters.')]),
-    Column('host_diet', [LeadingWhitespaceValidation()], allow_empty=True),
-    Column('source_material_id', [LeadingWhitespaceValidation()], allow_empty=True),
-    Column('ethnicity', [CanConvertValidation(str, message='Ethnicity may only contain alphanumeric characters.')], allow_empty=True),
-    Column('host_family_relationship', [LeadingWhitespaceValidation()], allow_empty=True),
+    Column('host_diet', [LeadingWhitespaceValidation()]),
+    Column('source_material_id', [LeadingWhitespaceValidation()]),
+    Column('ethnicity', [CanConvertValidation(str, message='Ethnicity may only contain alphanumeric characters.')]),
+    Column('host_family_relationship', [LeadingWhitespaceValidation()]),
     Column('host_genotype', [LeadingWhitespaceValidation() |
-                             MatchesPatternValidation(r'^[http|www]', message='Host Genotype may only be a valid URL to the associated DbGap project.')],
-           allow_empty=True),
-    Column('isolation_source', [LeadingWhitespaceValidation()], allow_empty=True), 
-    Column('samp_mat_process', [LeadingWhitespaceValidation()], allow_empty=True),
+                             MatchesPatternValidation(r'^[http|www]', message='Host Genotype may only be a valid URL to the associated DbGap project.')]),
+    Column('isolation_source', [LeadingWhitespaceValidation()]), 
+    Column('samp_mat_process', [LeadingWhitespaceValidation()]),
     Column('filename', [CustomSeriesValidation(lambda x: ~x.isnull(), 'A value is required for the filename column.'),
                         MatchesPatternValidation(r'\w+.[fastq|fasta|fq](.gz)?', message='Filename must be a valid fasta/fastq file with the following supported extensions: .fasta.gz, .fastq.gz, fq.gz')]),
     Column('sample_id', [CustomSeriesValidation(lambda x: ~x.isnull(), 'A value is required for the sample_id column.')]),
@@ -45,36 +44,37 @@ sample_schema = Schema([
                            InListValidation(['M', 'm', 'F', 'f'])]),
     Column('md5_checksum', [CustomSeriesValidation(lambda x: ~x.isnull(), 'A value is required for the pi_name column.'),
                             MatchesPatternValidation(r'[a-zA-Z0-9]{32}', message='MD5 Checksum may only contain 32 alphanumeric characters.')]),
-    Column('host_body_mass_index', [LeadingWhitespaceValidation() | CanConvertValidation(float)], allow_empty=True),
+    Column('host_body_mass_index', [LeadingWhitespaceValidation() | CanConvertValidation(float)]),
     Column('host_disease', [LeadingWhitespaceValidation() | 
-                            MatchesPatternValidation(r'DOID:\d+', message='Must provide a valid Disease Ontology ID in format \'DOID:<NUMBERS>\'')],
-           allow_empty=True),
+                            MatchesPatternValidation(r'DOID:\d+', message='Must provide a valid Disease Ontology ID in format \'DOID:<NUMBERS>\'')]),
     Column('variable_region', [CustomSeriesValidation(lambda x: ~x.isnull(), '') |
-                               MatchesPatternValidation(r'(V[1-9],?)+', message='Variable region must be a valid 16S hypervariable region.')],
-           allow_empty=True),
-    Column('gastrointest_disord', [LeadingWhitespaceValidation() | CanConvertValidation(int)], allow_empty=True),
+                               MatchesPatternValidation(r'(V[1-9],?)+', message='Variable region must be a valid 16S hypervariable region.')]),
+    Column('gastrointest_disord', [LeadingWhitespaceValidation() | CanConvertValidation(int)]),
     Column('host_body_product', [LeadingWhitespaceValidation() |
-                                 MatchesPatternValidation(r'GENEPIO_\d+', message='Must provide a valid Genetic epidemiology ontology ID in format \'GENEPIO_<NUMBERS>\'')],
-           allow_empty=True),
-    Column('host_phenotype', [LeadingWhitespaceValidation() | CanConvertValidation(int)], allow_empty=True),
+                                 MatchesPatternValidation(r'GENEPIO_\d+', message='Must provide a valid Genetic epidemiology ontology ID in format \'GENEPIO_<NUMBERS>\'')]),
+    Column('host_phenotype', [LeadingWhitespaceValidation() | CanConvertValidation(int)]),
     Column('ihmc_medication_code', [CustomSeriesValidation(lambda x: ~x.isnull(), '') |
-                                    MatchesPatternValidation(r'(\d+,?)+]', message='IHMC medication code must be a number.')], allow_empty=True),
+                                    MatchesPatternValidation(r'(\d+,?)+]', message='IHMC medication code must be a number.')]),
     Column('organism_count', [CustomSeriesValidation(lambda x: ~x.isnull(), '') |
-                              InRangeValidation(1, message='Organism count must be a positive number.')], allow_empty=True),
+                              InRangeValidation(1, message='Organism count must be a positive number.')]),
     Column('samp_store_dur', [LeadingWhitespaceValidation() | 
-                              InRangeValidation(1, message='Sample storage duration must be a positive number.')], allow_empty=True),
+                              InRangeValidation(1, message='Sample storage duration must be a positive number.')]),
     Column('samp_store_temp', [LeadingWhitespaceValidation() | 
-                               CanConvertValidation(int, message='Sample storage temperature must be a valid temperature number.')], allow_empty=True),
+                               CanConvertValidation(int, message='Sample storage temperature must be a valid temperature number.')]),
     Column('samp_vol_mass', [LeadingWhitespaceValidation() |
-                             MatchesPatternValidation(r'\d+[.]?\d*(g|ml)', message='Sample volume mass must be in format <NUMBER>g or <NUMBER>ml')], 
-           allow_empty=True),
+                             MatchesPatternValidation(r'\d+[.]?\d*(g|ml)', message='Sample volume mass must be in format <NUMBER>g or <NUMBER>ml')]),
     Column('sequencer', [InListValidation(["Illumina MiSeq", "Illumina NextSeq", "illumina miseq", "illumina nextseq",
                                            "Illumina HiSeq", "Illumina HiSeq X", "illumina hiseq", "illumina hiseq x",
                                            "PacBio Sequel", "Nanopore MinION", "pacbio sequel", "nanopore minion",
                                            "Nanopore PromethION", "Nanopore SmidgION", "nanopore promethion", "nanopore smidgion",
                                            "454", "Sanger", "sanger"])]),
     Column('read_number', [LeadingWhitespaceValidation() |
-                           InRangeValidation(1, message='Read number must be a positive number.')], allow_empty=True)
+                           InRangeValidation(1, message='Read number must be a positive number.')])
 ])
+
+sample_optional_cols = set(['read_number','host_body_mass_index','host_diet','host_disease','source_material_id',
+                            'variable_region','ethnicity','gastrointest_disord','host_body_product','host_family_relationship',
+                            'host_genotype','host_phenotype','ihmc_medication_code','isolation_source','organism_count',
+                            'samp_mat_process','samp_store_dur','samp_store_temp','samp_vol_mass'])
 
 schemas = {'sample': sample_schema, 'study': study_schema}

--- a/jdrf/jdrf/process_data.py
+++ b/jdrf/jdrf/process_data.py
@@ -142,7 +142,7 @@ def validate_sample_metadata(metadata_file, output_folder, logger):
     metadata_df = None
 
     try:
-       metadata_df = pd.read_csv(metadata_file, keep_default_na=False)
+       metadata_df = pd.read_csv(metadata_file, keep_default_na=False, parse_dates=['collection_date'])
        (is_valid, error_context) = _validate_metadata(metadata_df, 'sample', logger, output_folder)
     except pd.errors.ParserError as pe:
         if "Error tokenizing data" in pe.message:

--- a/jdrf/jdrf/process_data.py
+++ b/jdrf/jdrf/process_data.py
@@ -169,7 +169,10 @@ def _get_mismatched_columns(metadata_df, schema):
     valid_columns = set([c.name for c in schema.columns])
     metadata_columns = set(metadata_df.columns.tolist())
 
-    return list(valid_columns.symmetric_difference(metadata_columns))
+    extra_cols = list(metadata_columns.difference(valid_columns))
+    missing_cols = list(valid_columns.difference(metadata_columns))
+
+    return [extra_cols, missing_cols]
 
 
 def _validate_metadata(metadata_df, file_type, logger, output_folder=None):

--- a/jdrf/pages/templates/upload_metadata.html
+++ b/jdrf/pages/templates/upload_metadata.html
@@ -268,7 +268,7 @@
           </div>
         </div>
         <div id="upload_success" class="alert alert-success hidden" role="alert"><div class="glyphicon glyphicon-ok-sign"></div><div>Metadata successfully uploaded. Please proceed to the <a class="alert-link" href="{% url 'upload' %}">Upload Data</a> page to continue.</div></div>
-        <div id="date_format_audit" class="alert alert-warning hidden" role="alert"><div class="glyphicon glyphicon-exclamation-sign"></div><div>Please note that all dates found in the metadata have been auto-converted to YYYY-MM-DD (i.e. 2018-04-18) format for consistency.</div></div>
+        <div id="date_format_audit" class="alert alert-warning hidden" role="alert"><div class="glyphicon glyphicon-exclamation-sign"></div><div>Please note that all dates found in the metadata have been auto-converted to <b>YYYY-MM-DD</b> (i.e. <b>2018-04-18</b>) format for consistency.</div></div>
     </div> <!-- /container -->
   </body>
 </html>

--- a/jdrf/pages/templates/upload_metadata.html
+++ b/jdrf/pages/templates/upload_metadata.html
@@ -87,7 +87,6 @@
     <div class="container">
         <h2>Upload Metadata</h2>
         <p>Using the application on this page, upload study and sample metadata to deposit it with the JDRF MIBC for processing.</p>
-        <div class="alert alert-warning"><div class="glyphicon glyphicon-exclamation-sign"></div><div>Only one complete dataset (study and sample metadata + corresponding sequence files) may be processed at a time.</div></div>
 
         <div id="panel_study_metadata" class="panel panel-default">
           <div class="panel-heading">
@@ -269,6 +268,7 @@
           </div>
         </div>
         <div id="upload_success" class="alert alert-success hidden" role="alert"><div class="glyphicon glyphicon-ok-sign"></div><div>Metadata successfully uploaded. Please proceed to the <a class="alert-link" href="{% url 'upload' %}">Upload Data</a> page to continue.</div></div>
+        <div id="date_format_audit" class="alert alert-warning hidden" role="alert"><div class="glyphicon glyphicon-exclamation-sign"></div><div>Please note that all dates found in the metadata have been auto-converted to YYYY-MM-DD (i.e. 2018-04-18) format for consistency.</div></div>
     </div> <!-- /container -->
   </body>
 </html>

--- a/jdrf/static/js/jdrf_upload_metadata.js
+++ b/jdrf/static/js/jdrf_upload_metadata.js
@@ -70,7 +70,8 @@
     if (Cookies.get('sample_metadata') == '1') {
         $('#panel_sample_metadata .panel-body').hide();
         $('#panel_sample_metadata .panel-heading').html('<h3 class="panel-title">Sample Metadata <span class="pull-right glyphicon glyphicon-ok green"></span></h3>');
-        $('#upload_success').removeClass('hidden')
+        $('#upload_success').removeClass('hidden');
+        $('#date_format_audit').removeClass('hidden');
     }
 
     $('#study_metadata_form').validator().on('submit', function(e) {
@@ -246,6 +247,7 @@
             $('#validation').removeClass('hidden');
         } else {
             $('#upload_success').addClass('hidden');
+            $('#date_format_audit').addClass('hidden');
             Cookies.remove('sample_metadata');
 
             var errors_table = JSON.parse(response.errors_datatable);

--- a/jdrf/static/js/jdrf_upload_metadata.js
+++ b/jdrf/static/js/jdrf_upload_metadata.js
@@ -64,6 +64,7 @@
         })
         
         $('#metadata_complete').removeClass('hidden');
+        $('#date_format_audit').removeClass('hidden');
     }
 
     if (Cookies.get('sample_metadata') == '1') {
@@ -265,6 +266,7 @@
         $('#panel_sample_metadata .panel-heading').html('<h3 class="panel-title">Sample Metadata</h3>');
         $('#validation').addClass('hidden');
         $('#upload_success').addClass('hidden');
+        $('#date_format_audit').addClasss('hidden')
      });
      
      $('#metadata_file_upload').on('filebatchuploadsuccess', function(event, files, extra) {
@@ -273,6 +275,7 @@
         Cookies.set('sample_metadata', 1);
 
         $('#upload_success').removeClass('hidden');
+        $('#date_format_audit').removeClass('hidden');
      });
 
  });

--- a/jdrf/static/js/jdrf_upload_metadata.js
+++ b/jdrf/static/js/jdrf_upload_metadata.js
@@ -64,6 +64,7 @@
         })
         
         $('#metadata_complete').removeClass('hidden');
+        $('#date_format_audit').removeClass('hidden');
     }
 
     if (Cookies.get('sample_metadata') == '1') {
@@ -246,7 +247,7 @@
             $('#validation').removeClass('hidden');
         } else {
             $('#upload_success').addClass('hidden');
-            $('#date_format_audit').addClass('hidden');
+            $('#date_format_audit').addClass('hidden')
             Cookies.remove('sample_metadata');
 
             var errors_table = JSON.parse(response.errors_datatable);
@@ -267,7 +268,7 @@
         $('#panel_sample_metadata .panel-heading').html('<h3 class="panel-title">Sample Metadata</h3>');
         $('#validation').addClass('hidden');
         $('#upload_success').addClass('hidden');
-        $('#date_format_audit').addClasss('hidden')
+        $('#date_format_audit').addClass('hidden');
      });
      
      $('#metadata_file_upload').on('filebatchuploadsuccess', function(event, files, extra) {

--- a/jdrf/static/js/jdrf_upload_metadata.js
+++ b/jdrf/static/js/jdrf_upload_metadata.js
@@ -206,12 +206,31 @@
             // in the schema we can list out all the 
             var error_single_html = "";
             if ("mismatch_cols" in response) {
+                // We should get back two lists of columns here. One contains extra columns 
+                // while the other will contain any missing columns.
+                extra_cols = response['mismatch_cols'][0]
+                missing_cols = response['mismatch_cols'][1]
+
                 error_single_html += "<div class='glyphicon glyphicon-ban-circle'></div>" +
                                      "<div>" + response['error_msg'] + ":" + "</div><br />" +
-                                     "<div id='mismatch_cols'><ul>";
+                                     "<div id='mismatch_cols'>";
 
-                for (var col in response['mismatch_cols']) {
-                    error_single_html += "<li><b>" + response['mismatch_cols'][col] + "</b></li>";
+                if (missing_cols.length > 0) {
+                    error_single_html += "<b>Missing Columns:</b><br /><ul>";
+
+                    for (var col in missing_cols) {
+                        error_single_html += "<li><b>" + missing_cols[col] + "</b></li>";
+                    }
+
+                    error_single_html += "</ul><br />";
+                }
+
+                if (extra_cols.length > 0) {
+                    error_single_html += "<b>Extra Columns:</b><br /><ul>";
+
+                    for (var col in extra_cols) {
+                        error_single_html += "<li><b>" + extra_cols[col] + "</b></li>";
+                    }
                 }
 
                 error_single_html += "</ul></div>";

--- a/jdrf/static/js/jdrf_upload_metadata.js
+++ b/jdrf/static/js/jdrf_upload_metadata.js
@@ -64,7 +64,6 @@
         })
         
         $('#metadata_complete').removeClass('hidden');
-        $('#date_format_audit').removeClass('hidden');
     }
 
     if (Cookies.get('sample_metadata') == '1') {


### PR DESCRIPTION
I think I've covered all of the testing here, the biggest being the support of the "slim" metadata spreadsheets containing at minimum just the required columns and any number of the optional columns. The remaining optional columns will be filled in on the back-end.