### PR TITLE
Trigger inline-editing when encountering single metadata error

### DIFF
--- a/jdrf/pages/views.py
+++ b/jdrf/pages/views.py
@@ -202,10 +202,8 @@ def upload_sample_metadata(request):
             del field_updates['action']
 
             updated_metadata_file = process_data.update_metadata_file(field_updates, upload_folder, logger)
-            (is_valid, metadata_df, error_context) = process_data.validate_sample_metadata(updated_metadata_file, upload_folder, logger, inline=True)
+            (is_valid, metadata_df, error_context) = process_data.validate_sample_metadata(updated_metadata_file, upload_folder, logger)
             
-            logger.info(is_valid)
-
             if not is_valid:
                 data['error'] = 'Metadata validation failed!'
                 data.update(error_context)


### PR DESCRIPTION
Here are the small changes to trigger the datatable to appear when encountering a single metadata error.